### PR TITLE
Rename stimulus-rails-ujs to stimulus-remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@
 - [stimulus-tabs](https://github.com/jwald1/stimulus-tabs) - A simple tabs controller for StimulusJS.
 - [stimulus-data-bindings](https://gitlab.com/initforthe/stimulus-data-bindings) - One-way data binding controller for StimulusJS.
 - [stimulus-conductor](https://github.com/adrienpoly/stimulus-conductor) - An optionated StimulusJS Controller to easily manage parent/children controllers.
-- [stimulus-rails-ujs](https://gitlab.com/initforthe/stimulus-rails-ujs) - Rails UJS bindings for StimulusJS.
+- [stimulus-remote](https://gitlab.com/initforthe/stimulus-remote) - Stimulus controller to provide content handling for HTML sent over the wire whilst using Rails UJS.
 - [stimulus-sticky-table-header](https://github.com/johnbeatty/stimulus-sticky-table-header) - Sticky Table Header Controller Using StimulusJS.
 - [stimulus-inline-edit](https://github.com/eelcoj/stimulus-inline-edit) - A StimulusJS controller to add inline edit to Rails-powered input fields.
 - [stimulus-form-utilities](https://github.com/eelcoj/stimulus-form-utilities) - A set of small form utility helpers built with Stimulus.


### PR DESCRIPTION
Hi!

Seems that stimulus-rails-ujs project was renamed to stimulus-remote.

![image](https://user-images.githubusercontent.com/2051199/91279882-5bccbe00-e786-11ea-837a-982f8cd534a4.png)

You can get this message visiting the old URL.

Thank you for this list.