### PR TITLE
Add stimulus-durable-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 - [stimulus-transition](https://github.com/robbevp/stimulus-transition) - A stimulus controller to automatically run enter/leave transitions inspired by Vue and Alpine syntax.
 - [stimulus-library](https://github.com/Sub-Xaero/stimulus-library) - A set of useful pre-built and configurable StimulusJS controllers for various common scenarios.
 - [stimulus-store](https://github.com/omarluq/stimulus-store) - Lightweight state management for StimulusJS application.
-
+- [stimulus-durable-values](https://github.com/asgerb/stimulus-durable-values) – Easily make your Stimulus controller values persist through morphs
 
 
 ## Reading


### PR DESCRIPTION
Hi!
Thanks a lot for maintaining this repo.
I built a package for persisting controller values across (turbo) morphs.
Thought it would make sense to add to the list 🙂